### PR TITLE
INTTEMPLATES-1 Template not using artifactId

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>hillert-war</name>
+	<name>spring-integration-templates-root</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/README.md
+++ b/README.md
@@ -6,8 +6,4 @@ This repository contains templates and plugins that will help you to get Spring 
 * Spring Integration STS Plugin and Templates (**si-sts-templates**)
 * Spring Integration Gradle Plugin (**si-gradle-plugin**)
 
-Both the STS support and the Gradle Plugin provide the same set of templates that are located under **si-template-projects**
-
-If you encounter issues or have specific feature requests, please open a Jira support ticket at: 
-
-* https://jira.springsource.org/browse/INTTEMPLATES
+Both the STS support and the Gradle Plugin use the same set of template projects, which are located under **si-template-projects**

--- a/si-sts-templates/README.md
+++ b/si-sts-templates/README.md
@@ -1,7 +1,7 @@
 Spring Integration STS Plugin and Templates
 ===========================================
 
-This project provides an plugin and various projects for SpringSource Tool Suite™. 
+This project provides an plugin and various projects for SpringSource Tool Suite™.
 
 # How to build the project
 
@@ -12,17 +12,17 @@ In order to build the entire project run:
 This will result in *3 artifacts* being created under **target/out**:
 
 * descriptor.xml
-* org.springframework.integration.sts.templates_1.0.0.M2.jar
-* si-template-1.0.0.M2.zip
+* org.springframework.integration.sts.templates_1.0.0.M3.jar
+* si-template-1.0.0.M3.zip
 
 In order to deploy to STS you have 2 options:
 
-1. drop the Eclipse plugin **org.springframework.integration.sts.templates_1.0.0.M2.jar**
+1. drop the Eclipse plugin **org.springframework.integration.sts.templates_1.0.0.M3.jar**
    to your Eclipse STS **dropins/plugins folder**. Restart Eclipse STS.
 
 2. Option 2 is good for developing/changing the Eclipse STS template.
 
-Take the **si-template-1.0.0.M2.zip** jar file and unpack it in your Eclipse workspace in a directory called
+Take the **si-template-1.0.0.M3.zip** jar file and unpack it in your Eclipse workspace in a directory called
 **.metadata/.sts/content/${pom.artifactId}-${pom.version}**. Then add or edit the
 template descriptor in **.metadata/.plugins/com.springsource.sts.content.core/content.xml**
 so it has this form:

--- a/si-sts-templates/pom.xml
+++ b/si-sts-templates/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.integration.sts.templates</groupId>
     <artifactId>si-template-parent</artifactId>
-    <version>1.0.0.M2</version>
+    <version>1.0.0.M3</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/si-sts-templates/si-template-plugin/META-INF/MANIFEST.MF
+++ b/si-sts-templates/si-template-plugin/META-INF/MANIFEST.MF
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Spring Integration STS Plugin
 Bundle-SymbolicName: org.springframework.integration.sts.templates;singleton:=true
-Bundle-Version: 1.0.0.M2
+Bundle-Version: 1.0.0.M3

--- a/si-sts-templates/si-template-plugin/pom.xml
+++ b/si-sts-templates/si-template-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.integration.sts.templates</groupId>
         <artifactId>si-template-parent</artifactId>
-        <version>1.0.0.M2</version>
+        <version>1.0.0.M3</version>
     </parent>
     <artifactId>si-template-plugin</artifactId>
     <packaging>pom</packaging>

--- a/si-sts-templates/si-template-standalone-simple/pom.xml
+++ b/si-sts-templates/si-template-standalone-simple/pom.xml
@@ -4,13 +4,13 @@
 
     <groupId>org.springframework.integration.sts.templates</groupId>
     <artifactId>si-template-standalone-simple</artifactId>
-    <version>1.0.0.M2</version>
+    <version>1.0.0.M3</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.springframework.integration.sts.templates</groupId>
         <artifactId>si-template-parent</artifactId>
-        <version>1.0.0.M2</version>
+        <version>1.0.0.M3</version>
     </parent>
 
     <properties>

--- a/si-sts-templates/si-template-standalone-simple/template/wizard.json
+++ b/si-sts-templates/si-template-standalone-simple/template/wizard.json
@@ -39,7 +39,7 @@
 
         "topLevelPackage" : "stsorg.stsspringframework.stsintegration.mysubsystem",
 
-        "projectName" : "si-template-project-standalone-simple",
+        "projectName" : "si-template-project-name",
 
         "pages" : {
             "page" : [

--- a/si-sts-templates/si-template-standalone/pom.xml
+++ b/si-sts-templates/si-template-standalone/pom.xml
@@ -4,13 +4,13 @@
 
     <groupId>org.springframework.integration.sts.templates</groupId>
     <artifactId>si-template-standalone</artifactId>
-    <version>1.0.0.M2</version>
+    <version>1.0.0.M3</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.springframework.integration.sts.templates</groupId>
         <artifactId>si-template-parent</artifactId>
-        <version>1.0.0.M2</version>
+        <version>1.0.0.M3</version>
     </parent>
 
     <properties>

--- a/si-sts-templates/si-template-standalone/template/wizard.json
+++ b/si-sts-templates/si-template-standalone/template/wizard.json
@@ -10,7 +10,7 @@
                     "required" : true,
                 },
                 {
-                    "name" : "mavenArtifactId",
+                    "name" : "si-template-standalone-artifactId",
                     "description" : "Please enter an 'artifactId'",
                     "type" : "java.lang.String",
                     "page" : 0,
@@ -39,7 +39,7 @@
 
         "topLevelPackage" : "stsorg.stsspringframework.stsintegration.mysubsystem",
 
-        "projectName" : "si-template-project-java",
+        "projectName" : "si-template-project-name",
 
         "pages" : {
             "page" : [

--- a/si-sts-templates/si-template-war/pom.xml
+++ b/si-sts-templates/si-template-war/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>org.springframework.integration.sts.templates</groupId>
         <artifactId>si-template-parent</artifactId>
-        <version>1.0.0.M2</version>
+        <version>1.0.0.M3</version>
     </parent>
 
     <groupId>org.springframework.integration.sts.templates</groupId>
     <artifactId>si-template-war</artifactId>
-    <version>1.0.0.M2</version>
+    <version>1.0.0.M3</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/si-template-projects/si-template-standalone-project/.project
+++ b/si-template-projects/si-template-standalone-project/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>si-template-standalone</name>
+	<name>si-template-project-name</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/si-template-projects/si-template-standalone-project/pom.xml
+++ b/si-template-projects/si-template-standalone-project/pom.xml
@@ -7,7 +7,7 @@
     <version>mavenVersion</version>
     <packaging>jar</packaging>
 
-    <name>si-template-project-standalone</name>
+    <name>si-template-project-name</name>
     <url>http://www.springsource.org/spring-integration</url>
 
     <prerequisites>

--- a/si-template-projects/si-template-standalone-project/src/main/java/stsorg/stsspringframework/stsintegration/Main.java
+++ b/si-template-projects/si-template-standalone-project/src/main/java/stsorg/stsspringframework/stsintegration/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/si-template-projects/si-template-standalone-project/src/main/java/stsorg/stsspringframework/stsintegration/SpringIntegrationUtils.java
+++ b/si-template-projects/si-template-standalone-project/src/main/java/stsorg/stsspringframework/stsintegration/SpringIntegrationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/si-template-projects/si-template-standalone-project/src/main/java/stsorg/stsspringframework/stsintegration/TransformationHandler.java
+++ b/si-template-projects/si-template-standalone-project/src/main/java/stsorg/stsspringframework/stsintegration/TransformationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/si-template-projects/si-template-standalone-project/src/test/java/stsorg/stsspringframework/stsintegration/SpringIntegrationProjectStartupTest.java
+++ b/si-template-projects/si-template-standalone-project/src/test/java/stsorg/stsspringframework/stsintegration/SpringIntegrationProjectStartupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/si-template-projects/si-template-standalone-simple-project/.project
+++ b/si-template-projects/si-template-standalone-simple-project/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>si-template-standalone-simple</name>
+	<name>si-template-project-name</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/si-template-projects/si-template-standalone-simple-project/pom.xml
+++ b/si-template-projects/si-template-standalone-simple-project/pom.xml
@@ -7,7 +7,7 @@
     <version>mavenVersion</version>
     <packaging>jar</packaging>
 
-    <name>si-template-project-standalone-simple</name>
+    <name>si-template-project-name</name>
     <url>http://www.springsource.org/spring-integration</url>
 
     <prerequisites>

--- a/si-template-projects/si-template-standalone-simple-project/src/main/java/stsorg/stsspringframework/stsintegration/Main.java
+++ b/si-template-projects/si-template-standalone-simple-project/src/main/java/stsorg/stsspringframework/stsintegration/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/si-template-projects/si-template-standalone-simple-project/src/main/java/stsorg/stsspringframework/stsintegration/service/StringConversionService.java
+++ b/si-template-projects/si-template-standalone-simple-project/src/main/java/stsorg/stsspringframework/stsintegration/service/StringConversionService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors
+ * Copyright 2002-2012 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.

--- a/si-template-projects/si-template-standalone-simple-project/src/test/java/stsorg/stsspringframework/stsintegration/StringConversionServiceTest.java
+++ b/si-template-projects/si-template-standalone-simple-project/src/test/java/stsorg/stsspringframework/stsintegration/StringConversionServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,7 @@ public class StringConversionServiceTest {
 
     @Test
     public void testStartupOfSpringInegrationContext() throws Exception{
-        final ApplicationContext context
-            = new ClassPathXmlApplicationContext("/META-INF/spring/integration/spring-integration-context.xml",
+        new ClassPathXmlApplicationContext("/META-INF/spring/integration/spring-integration-context.xml",
                                                   StringConversionServiceTest.class);
         Thread.sleep(2000);
     }

--- a/si-template-projects/si-template-war-project/src/main/java/stsorg/stsspringframework/stsintegration/model/TwitterMessage.java
+++ b/si-template-projects/si-template-war-project/src/main/java/stsorg/stsspringframework/stsintegration/model/TwitterMessage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors
+ * Copyright 2002-2012 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.

--- a/si-template-projects/si-template-war-project/src/main/java/stsorg/stsspringframework/stsintegration/mvc/controller/HomeController.java
+++ b/si-template-projects/si-template-war-project/src/main/java/stsorg/stsspringframework/stsintegration/mvc/controller/HomeController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors
+ * Copyright 2002-2012 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.

--- a/si-template-projects/si-template-war-project/src/main/java/stsorg/stsspringframework/stsintegration/service/TwitterService.java
+++ b/si-template-projects/si-template-war-project/src/main/java/stsorg/stsspringframework/stsintegration/service/TwitterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors
+ * Copyright 2002-2012 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.

--- a/si-template-projects/si-template-war-project/src/main/java/stsorg/stsspringframework/stsintegration/service/impl/DefaultTwitterService.java
+++ b/si-template-projects/si-template-war-project/src/main/java/stsorg/stsspringframework/stsintegration/service/impl/DefaultTwitterService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors
+ * Copyright 2002-2012 the original author or authors
  *
  *     Licensed under the Apache License, Version 2.0 (the "License");
  *     you may not use this file except in compliance with the License.

--- a/si-template-projects/si-template-war-project/src/test/java/stsorg/stsspringframework/stsintegration/SpringIntegrationTest.java
+++ b/si-template-projects/si-template-war-project/src/test/java/stsorg/stsspringframework/stsintegration/SpringIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2010 the original author or authors.
+ * Copyright 2002-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The standalone (File) Template does not use the artifactId that you provide in the wizard

For reference see: https://jira.springsource.org/browse/INTTEMPLATES-1

Also updated:
- license header (year)
- version: changed M2 to M3
