### PR TITLE
INTTEMPLATES-23 - Preserve executable bit of gradlew

### DIFF
--- a/si-sts-templates/src/main/assembly/adapter.xml
+++ b/si-sts-templates/src/main/assembly/adapter.xml
@@ -17,6 +17,8 @@
 				<exclude>**/.DS_Store</exclude>
 				<exclude>**/.settings/**</exclude>
 				<exclude>**/.pmd</exclude>
+				<exclude>**/.gradle/**</exclude>
+				<exclude>**/gradlew</exclude>
 				<exclude>**/.idea/**</exclude>
 				<exclude>**/build/**</exclude>
 				<exclude>**/*.iml</exclude>
@@ -33,6 +35,11 @@
 		<file>
 			<source>${project.basedir}/../si-template-projects/adapter/.settings/org.eclipse.jdt.core.prefs</source>
 			<outputDirectory>.settings</outputDirectory>
+		</file>
+		<file>
+			<source>${project.basedir}/../si-template-projects/adapter/gradlew</source>
+			<outputDirectory></outputDirectory>
+			<fileMode>0755</fileMode>
 		</file>
 	</files>
 </assembly>

--- a/si-template-projects/adapter/gradle/wrapper/gradle-wrapper.properties
+++ b/si-template-projects/adapter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 03 16:33:44 EDT 2013
+#Thu Apr 18 22:56:20 EDT 2013
+zipStorePath=wrapper/dists
 distributionBase=GRADLE_USER_HOME
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.5-bin.zip
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.5-bin.zip


### PR DESCRIPTION
- Set executable permission for gradlew in `si-sts-templates/src/main/assembly/adapter.xml`
- Exclude `.gradle` directory for assembly
