### PR TITLE
URL Cleanup

### DIFF
--- a/si-sts-templates/pom.xml
+++ b/si-sts-templates/pom.xml
@@ -16,7 +16,7 @@
 			<id>ghillert</id>
 			<name>Gunnar Hillert</name>
 			<email>ghillert at vmware dot com</email>
-			<url>http://blog.hillert.com</url>
+			<url>https://blog.hillert.com</url>
 			<roles>
 				<role>Admin</role>
 			</roles>

--- a/si-template-projects/adapter/build.gradle
+++ b/si-template-projects/adapter/build.gradle
@@ -17,8 +17,8 @@ apply plugin: 'idea'
 group = 'SI-TEMPLATE-GROUP-ID'
 
 repositories {
-	maven { url 'http://repo.springsource.org/libs-milestone' }
-	maven { url 'http://repo.springsource.org/plugins-release' }
+	maven { url 'https://repo.springsource.org/libs-milestone' }
+	maven { url 'https://repo.springsource.org/plugins-release' }
 }
 
 sourceCompatibility=1.6
@@ -48,8 +48,8 @@ sourceSets {
 	}
 }
 
-// See http://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
-// and http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
+// See https://www.gradle.org/docs/current/userguide/dependency_management.html#sub:configurations
+// and https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html
 configurations {
 	jacoco //Configuration Group used by Sonar to provide Code Coverage using JaCoCo
 }

--- a/si-template-projects/adapter/publish-maven.gradle
+++ b/si-template-projects/adapter/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = 'https://github.com/SpringSource/spring-integration-extensions'
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org'
+				url = 'https://spring.io'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/si-template-projects/si-template-standalone-project/build.gradle
+++ b/si-template-projects/si-template-standalone-project/build.gradle
@@ -6,7 +6,7 @@ apply from: 'publish-maven.gradle'
 
 repositories {
 	mavenCentral()
-	maven { url 'http://repo.springsource.org/libs-milestone' }
+	maven { url 'https://repo.springsource.org/libs-milestone' }
 }
 
 group   = "SI-TEMPLATE-GROUP-ID"

--- a/si-template-projects/si-template-standalone-project/pom.xml
+++ b/si-template-projects/si-template-standalone-project/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>si-template-project-name</name>
-	<url>http://www.springsource.org/spring-integration</url>
+	<url>https://www.springsource.org/spring-integration</url>
 
 	<prerequisites>
 		<maven>2.2.1</maven>

--- a/si-template-projects/si-template-standalone-project/publish-maven.gradle
+++ b/si-template-projects/si-template-standalone-project/publish-maven.gradle
@@ -31,16 +31,16 @@ def customizePom(pom, gradleProject) {
 		generatedPom.project {
 			name = gradleProject.description
 			description = gradleProject.description
-			url = 'http://www.springsource.org/spring-integration'
+			url = 'https://www.springsource.org/spring-integration'
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org'
+				url = 'https://spring.io'
 			}
 
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/si-template-projects/si-template-standalone-simple-project/build.gradle
+++ b/si-template-projects/si-template-standalone-simple-project/build.gradle
@@ -6,7 +6,7 @@ apply from: 'publish-maven.gradle'
 
 repositories {
 	mavenCentral()
-	maven { url 'http://repo.springsource.org/libs-milestone' }
+	maven { url 'https://repo.springsource.org/libs-milestone' }
 }
 
 group   = "SI-TEMPLATE-GROUP-ID"

--- a/si-template-projects/si-template-standalone-simple-project/pom.xml
+++ b/si-template-projects/si-template-standalone-simple-project/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>si-template-project-name</name>
-	<url>http://www.springsource.org/spring-integration</url>
+	<url>https://www.springsource.org/spring-integration</url>
 
 	<prerequisites>
 		<maven>2.2.1</maven>

--- a/si-template-projects/si-template-standalone-simple-project/publish-maven.gradle
+++ b/si-template-projects/si-template-standalone-simple-project/publish-maven.gradle
@@ -31,16 +31,16 @@ def customizePom(pom, gradleProject) {
 		generatedPom.project {
 			name = gradleProject.description
 			description = gradleProject.description
-			url = 'http://www.springsource.org/spring-integration'
+			url = 'https://www.springsource.org/spring-integration'
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org'
+				url = 'https://spring.io'
 			}
 
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}

--- a/si-template-projects/si-template-war-project/build.gradle
+++ b/si-template-projects/si-template-war-project/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'idea'
 
 repositories {
 	mavenCentral()
-	maven { url 'http://repo.springsource.org/libs-milestone' }
+	maven { url 'https://repo.springsource.org/libs-milestone' }
 }
 
 group   = "mavenGroupId"

--- a/si-template-projects/si-template-war-project/pom.xml
+++ b/si-template-projects/si-template-war-project/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>war</packaging>
 
 	<name>si-template-project-name</name>
-	<url>http://www.springsource.org/spring-integration</url>
+	<url>https://www.springsource.org/spring-integration</url>
 
 	<prerequisites>
 		<maven>2.2.1</maven>

--- a/si-template-projects/si-template-war-project/publish-maven.gradle
+++ b/si-template-projects/si-template-war-project/publish-maven.gradle
@@ -31,16 +31,16 @@ def customizePom(pom, gradleProject) {
 		generatedPom.project {
 			name = gradleProject.description
 			description = gradleProject.description
-			url = 'http://www.springsource.org/spring-integration'
+			url = 'https://www.springsource.org/spring-integration'
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org'
+				url = 'https://spring.io'
 			}
 
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://blog.hillert.com (UnknownHostException) migrated to:  
  https://blog.hillert.com ([https](https://blog.hillert.com) result UnknownHostException).

## Fixed Success 
These URLs were fixed successfully.

* http://springsource.org (301) migrated to:  
  https://spring.io ([https](https://springsource.org) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/plugins-release migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html migrated to:  
  https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html ([https](https://www.gradle.org/docs/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html) result 301).
* http://www.gradle.org/docs/current/userguide/dependency_management.html migrated to:  
  https://www.gradle.org/docs/current/userguide/dependency_management.html ([https](https://www.gradle.org/docs/current/userguide/dependency_management.html) result 301).
* http://www.springsource.org/spring-integration migrated to:  
  https://www.springsource.org/spring-integration ([https](https://www.springsource.org/spring-integration) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance