### PR TITLE
URL Cleanup

### DIFF
--- a/si-gradle-plugin/LICENSE.txt
+++ b/si-gradle-plugin/LICENSE.txt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/ProjectGenerator.groovy
+++ b/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/ProjectGenerator.groovy
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/ProjectInformation.groovy
+++ b/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/ProjectInformation.groovy
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/SimpleProjectTask.groovy
+++ b/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/SimpleProjectTask.groovy
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/SpringIntegrationPlugin.groovy
+++ b/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/SpringIntegrationPlugin.groovy
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/SpringIntegrationPluginUtils.groovy
+++ b/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/SpringIntegrationPluginUtils.groovy
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/StandaloneProjectTask.groovy
+++ b/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/StandaloneProjectTask.groovy
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/WarProjectTask.groovy
+++ b/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/WarProjectTask.groovy
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,

--- a/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/support/TemplateType.groovy
+++ b/si-gradle-plugin/src/main/groovy/org/springframework/integration/gradle/support/TemplateType.groovy
@@ -5,7 +5,7 @@
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
-*      http://www.apache.org/licenses/LICENSE-2.0
+*      https://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 9 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).